### PR TITLE
Fix missing data files on install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
-    include_package_data=False,
+    include_package_data=True,
     zip_safe=False,
     test_suite=test_suite,
 


### PR DESCRIPTION
`include_package_data=False` prevents the use of the `MANIFEST.in` hence some data files under `exodata/data/` where missing, see [1] under `include_package_data`.

[1]: https://pythonhosted.org/setuptools/setuptools.html#new-and-changed-setup-keywords